### PR TITLE
YADU (yet another datomic upgrade)

### DIFF
--- a/src/leiningen/new/om_async_tut/project.clj
+++ b/src/leiningen/new/om_async_tut/project.clj
@@ -13,7 +13,7 @@
                  [om "0.5.2"]
                  [compojure "1.1.6"]
                  [fogus/ring-edn "0.2.0"]
-                 [com.datomic/datomic-free "0.9.4578"]]
+                 [com.datomic/datomic-free "0.9.4699"]]
 
   :plugins [[lein-cljsbuild "1.0.2"]]
 


### PR DESCRIPTION
Was getting `IllegalStateExceptionInfo :db.error/log-version This version of Datomic cannot read log version 3  datomic.error/state (error.clj:64)` with the latest Datomic.
