### PR TITLE
Remove annoying charset errors in browser console

### DIFF
--- a/src/leiningen/new/om_async_tut/index.html
+++ b/src/leiningen/new/om_async_tut/index.html
@@ -1,5 +1,6 @@
 <html>
     <head>
+        <meta charset='utf-8'>
         <style>
             ul li input {
                 width: 400px;


### PR DESCRIPTION
Charset of course works anyway, but charset errors in the console is cluttering when we want to work in the console.
