### PR TITLE
Update dependencies and use Figwheel

### DIFF
--- a/src/leiningen/new/om_async_tut.clj
+++ b/src/leiningen/new/om_async_tut.clj
@@ -11,7 +11,7 @@
     (main/info "Generating fresh 'lein new' om-async-tut project.")
     (->files data
       ["project.clj" (render "project.clj" data)]
-      [".gitignore" (render "giignore" data)]
+      [".gitignore" (render "gitgnore" data)]
       ["resources/data/schema.edn" (render "schema.edn" data)]
       ["resources/data/initial.edn" (render "initial.edn" data)]
       ["resources/public/html/index.html" (render "index.html" data)]

--- a/src/leiningen/new/om_async_tut.clj
+++ b/src/leiningen/new/om_async_tut.clj
@@ -11,6 +11,7 @@
     (main/info "Generating fresh 'lein new' om-async-tut project.")
     (->files data
       ["project.clj" (render "project.clj" data)]
+      [".gitignore" (render "giignore" data)]
       ["resources/data/schema.edn" (render "schema.edn" data)]
       ["resources/data/initial.edn" (render "initial.edn" data)]
       ["resources/public/html/index.html" (render "index.html" data)]

--- a/src/leiningen/new/om_async_tut.clj
+++ b/src/leiningen/new/om_async_tut.clj
@@ -11,7 +11,7 @@
     (main/info "Generating fresh 'lein new' om-async-tut project.")
     (->files data
       ["project.clj" (render "project.clj" data)]
-      [".gitignore" (render "gitgnore" data)]
+      [".gitignore" (render "gitignore" data)]
       ["resources/data/schema.edn" (render "schema.edn" data)]
       ["resources/data/initial.edn" (render "initial.edn" data)]
       ["resources/public/html/index.html" (render "index.html" data)]

--- a/src/leiningen/new/om_async_tut/client.cljs
+++ b/src/leiningen/new/om_async_tut/client.cljs
@@ -13,4 +13,4 @@
 
 (println "Hello world!")
 
-(fw/start {:websocket-url "ws://localhost:3449/figwheel-ws"})
+(fw/start {})

--- a/src/leiningen/new/om_async_tut/client.cljs
+++ b/src/leiningen/new/om_async_tut/client.cljs
@@ -1,5 +1,6 @@
 (ns {{name}}.core
   (:require [cljs.reader :as reader]
+            [figwheel.client :as fw]
             [goog.events :as events]
             [goog.dom :as gdom]
             [om.core :as om :include-macros true]
@@ -11,3 +12,5 @@
 (enable-console-print!)
 
 (println "Hello world!")
+
+(fw/start {:websocket-url "ws://localhost:3449/figwheel-ws"})

--- a/src/leiningen/new/om_async_tut/client.cljs
+++ b/src/leiningen/new/om_async_tut/client.cljs
@@ -13,4 +13,4 @@
 
 (println "Hello world!")
 
-(fw/start {})
+(fw/start {:websocket-url "ws://localhost:3449/figwheel-ws"})

--- a/src/leiningen/new/om_async_tut/gitignore
+++ b/src/leiningen/new/om_async_tut/gitignore
@@ -1,0 +1,6 @@
+target/
+bin/
+.lein-repl-history
+.nrepl-port
+resources/public/js
+figwheel_server.log

--- a/src/leiningen/new/om_async_tut/index.html
+++ b/src/leiningen/new/om_async_tut/index.html
@@ -11,9 +11,6 @@
     </head>
     <body>
         <div id="classes"></div>
-        <script src="http://fb.me/react-0.9.0.js"></script>
-        <script src="js/out/goog/base.js" type="text/javascript"></script>
         <script src="js/main.js" type="text/javascript"></script>
-        <script type="text/javascript">goog.require("{{sanitized}}.core");</script>
     </body>
 </html>

--- a/src/leiningen/new/om_async_tut/project.clj
+++ b/src/leiningen/new/om_async_tut/project.clj
@@ -6,25 +6,31 @@
 
   :jvm-opts ^:replace ["-Xmx1g" "-server"]
 
-  :dependencies [[org.clojure/clojure "1.5.1"]
-                 [org.clojure/clojurescript "0.0-2173"]
-                 [ring/ring "1.2.1"]
-                 [org.clojure/core.async "0.1.267.0-0d7780-alpha"]
-                 [om "0.5.3"]
-                 [compojure "1.1.6"]
+  :dependencies [[org.clojure/clojure "1.6.0"]
+                 [org.clojure/clojurescript "0.0-2727"]
+                 [org.clojure/core.async "0.1.346.0-17112a-alpha"]
+                 [org.omcljs/om "0.8.7"]
+                 [ring "1.3.2"]
+                 [compojure "1.3.1"]
+                 [figwheel "0.2.2-SNAPSHOT"]
                  [fogus/ring-edn "0.2.0"]
-                 [com.datomic/datomic-free "0.9.4699"]]
+                 [com.datomic/datomic-free "0.9.5130" :exclusions [joda-time]]]
 
-  :plugins [[lein-cljsbuild "1.0.2"]]
+  :plugins [[lein-cljsbuild "1.0.4"]
+            [lein-ring "0.9.1"]
+            [lein-figwheel "0.2.2-SNAPSHOT"]]
+
 
   :source-paths ["src/clj" "src/cljs"]
   :resource-paths ["resources"]
+  :clean-targets ^{:protect false} ["resources/public/js/out"
+                                    "resources/public/js/main.js"]
 
   :cljsbuild {
-    :builds [{:id "dev"
-              :source-paths ["src/clj" "src/cljs"]
-              :compiler {
-                :output-to "resources/public/js/main.js"
-                :output-dir "resources/public/js/out"
-                :optimizations :none
-                :source-map true}}]})
+              :builds [{:id "dev"
+                        :source-paths ["src/clj" "src/cljs"]
+                        :compiler {
+                                   :output-to "resources/public/js/main.js"
+                                   :output-dir "resources/public/js/out"
+                                   :optimizations :none
+                                   :source-map true}}]})

--- a/src/leiningen/new/om_async_tut/project.clj
+++ b/src/leiningen/new/om_async_tut/project.clj
@@ -26,11 +26,13 @@
   :clean-targets ^{:protect false} ["resources/public/js/out"
                                     "resources/public/js/main.js"]
 
-  :cljsbuild {
-              :builds [{:id "dev"
+  :ring {:handler {{name}}.core/app}
+
+  :cljsbuild {:builds [{:id "dev"
                         :source-paths ["src/clj" "src/cljs"]
-                        :compiler {
-                                   :output-to "resources/public/js/main.js"
+                        :compiler {:output-to "resources/public/js/main.js"
                                    :output-dir "resources/public/js/out"
+                                   :main {{name}}.core
+                                   :asset-path "js/out"
                                    :optimizations :none
                                    :source-map true}}]})

--- a/src/leiningen/new/om_async_tut/project.clj
+++ b/src/leiningen/new/om_async_tut/project.clj
@@ -17,6 +17,7 @@
                  [com.datomic/datomic-free "0.9.5130" :exclusions [joda-time]]]
 
   :plugins [[lein-cljsbuild "1.0.4"]
+            [lein-ring "0.9.1"]
             [lein-figwheel "0.2.2-SNAPSHOT"]]
 
 
@@ -25,7 +26,8 @@
   :clean-targets ^{:protect false} ["resources/public/js/out"
                                     "resources/public/js/main.js"]
 
-  :figwheel {:ring-handler {{name}}.core/handler}
+  :ring {:handler om-async.core/handler
+         :port 8000}
 
   :cljsbuild {:builds [{:id "dev"
                         :source-paths ["src/clj" "src/cljs"]

--- a/src/leiningen/new/om_async_tut/project.clj
+++ b/src/leiningen/new/om_async_tut/project.clj
@@ -17,7 +17,6 @@
                  [com.datomic/datomic-free "0.9.5130" :exclusions [joda-time]]]
 
   :plugins [[lein-cljsbuild "1.0.4"]
-            [lein-ring "0.9.1"]
             [lein-figwheel "0.2.2-SNAPSHOT"]]
 
 
@@ -26,7 +25,7 @@
   :clean-targets ^{:protect false} ["resources/public/js/out"
                                     "resources/public/js/main.js"]
 
-  :ring {:handler {{name}}.core/app}
+  :figwheel {:ring-handler {{name}}.core/handler}
 
   :cljsbuild {:builds [{:id "dev"
                         :source-paths ["src/clj" "src/cljs"]

--- a/src/leiningen/new/om_async_tut/server.clj
+++ b/src/leiningen/new/om_async_tut/server.clj
@@ -48,9 +48,6 @@
     (update-class (:id params) edn-params))
   (route/files "/" {:root "resources/public"}))
 
-(def app
+(def handler 
   (-> routes
       wrap-edn-params))
-
-(defonce server
-  (run-jetty #'app {:port 8080 :join? false}))


### PR DESCRIPTION
Hi David,

I updated the template for a new version of the tutorial that uses Figwheel instead of LightTable. I also added lein-ring to run the backend code. Let me know if you decide to merge this and publish the template, so I can update the tutorial at the same time. The new version of the tutorial is [here](https://github.com/bensu/basic-om-tut/blob/master/Intermediate-Tutorial.md) if you want to take a look.

Hope this helps