### PR TITLE
Corrected hardcoded {{name}} bug and updated dependencies.

### DIFF
--- a/src/leiningen/new/om_async_tut/client.cljs
+++ b/src/leiningen/new/om_async_tut/client.cljs
@@ -2,7 +2,6 @@
   (:require [cljs.reader :as reader]
             [figwheel.client :as fw]
             [goog.events :as events]
-            [goog.dom :as gdom]
             [om.core :as om :include-macros true]
             [om.dom :as dom :include-macros true])
   (:import [goog.net XhrIo]
@@ -13,4 +12,4 @@
 
 (println "Hello world!")
 
-(fw/start {:websocket-url "ws://localhost:3449/figwheel-ws"})
+(fw/start {})

--- a/src/leiningen/new/om_async_tut/project.clj
+++ b/src/leiningen/new/om_async_tut/project.clj
@@ -10,7 +10,7 @@
                  [org.clojure/clojurescript "0.0-2850"]
                  [org.clojure/core.async "0.1.346.0-17112a-alpha"]
                  [org.omcljs/om "0.8.8"]
-                 [om-sync "0.1.22"]
+                 [om-sync "0.1.5"]
                  [ring "1.3.2"]
                  [compojure "1.3.1"]
                  [figwheel "0.2.4-SNAPSHOT"]

--- a/src/leiningen/new/om_async_tut/project.clj
+++ b/src/leiningen/new/om_async_tut/project.clj
@@ -10,7 +10,6 @@
                  [org.clojure/clojurescript "0.0-2850"]
                  [org.clojure/core.async "0.1.346.0-17112a-alpha"]
                  [org.omcljs/om "0.8.8"]
-                 [om-sync "0.1.5"]
                  [ring "1.3.2"]
                  [compojure "1.3.1"]
                  [figwheel "0.2.4-SNAPSHOT"]

--- a/src/leiningen/new/om_async_tut/project.clj
+++ b/src/leiningen/new/om_async_tut/project.clj
@@ -7,18 +7,18 @@
   :jvm-opts ^:replace ["-Xmx1g" "-server"]
 
   :dependencies [[org.clojure/clojure "1.6.0"]
-                 [org.clojure/clojurescript "0.0-2727"]
+                 [org.clojure/clojurescript "0.0-2850"]
                  [org.clojure/core.async "0.1.346.0-17112a-alpha"]
-                 [org.omcljs/om "0.8.7"]
+                 [org.omcljs/om "0.8.8"]
+                 [om-sync "0.1.22"]
                  [ring "1.3.2"]
                  [compojure "1.3.1"]
-                 [figwheel "0.2.2-SNAPSHOT"]
+                 [figwheel "0.2.4-SNAPSHOT"]
                  [fogus/ring-edn "0.2.0"]
                  [com.datomic/datomic-free "0.9.5130" :exclusions [joda-time]]]
 
   :plugins [[lein-cljsbuild "1.0.4"]
-            [lein-ring "0.9.1"]
-            [lein-figwheel "0.2.2-SNAPSHOT"]]
+            [lein-figwheel "0.2.4-SNAPSHOT"]]
 
 
   :source-paths ["src/clj" "src/cljs"]
@@ -26,8 +26,7 @@
   :clean-targets ^{:protect false} ["resources/public/js/out"
                                     "resources/public/js/main.js"]
 
-  :ring {:handler om-async.core/handler
-         :port 8000}
+  :figwheel {:ring-handler {{name}}.core/handler}
 
   :cljsbuild {:builds [{:id "dev"
                         :source-paths ["src/clj" "src/cljs"]


### PR DESCRIPTION
Changes:
1. Important: Corrected name in the ring handler name, which wouldn't work with any project not named `om-async`.
2. Dependencies updated to leverage Figwheel's `:ring-handler` option. It removes overhead from the server side of the tutorial.
3. Upgrading ClojureScript brought problems with Google DOM (I think), which was removed.

If you decide to publish this changes, let me know so I can update the tutorial accordingly.

Thanks!
